### PR TITLE
feat: get pip dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"     


### PR DESCRIPTION
adds pip dependency checks to dependabot
we need to finetune the deploy to testPyPi so that external PRs don't constantly fail. 
